### PR TITLE
SVEA-58: SSN handling for Finland

### DIFF
--- a/src/app/code/community/Svea/WebPay/Model/Observer.php
+++ b/src/app/code/community/Svea/WebPay/Model/Observer.php
@@ -1,0 +1,45 @@
+<?php
+
+class Svea_WebPay_Model_Observer
+{
+
+    /**
+     * Add svea payment info that will be displayed when viewing orders
+     *
+     * Should be run on 'payment_info_block_prepare_specific_information'.
+     *
+     * Currently only ssn/orgnr is added _if_ the billing country is Finland,
+     * because for Finland the getaddress calls are not made.
+     *
+     */
+    public function addSveaPaymentInfo(Varien_Event_Observer $observer)
+    {
+        $payment = $observer->getEvent()->getPayment();
+        if (!preg_match('/svea/', $payment->getMethod())) {
+            return;
+        }
+
+        $transport = $observer->getEvent()->getTransport();
+        $order = $payment->getOrder();
+        if (null === $order || !$order->getId()) {
+            return;
+        }
+
+        $countryId = $order->getBillingAddress()->getCountryId();
+
+        if ($countryId === 'FI') {
+            $helper = Mage::helper('svea_webpay');
+            $additionalData = $payment->getAdditionalInformation();
+            if ((int)$additionalData['svea_customerType'] === 0) {
+                $ssnLabel = $helper->__('text_ssn');
+                $customerType = $helper->__('private');
+            } else {
+                $ssnLabel = $helper->__('text_vat_no');
+                $customerType = $helper->__('company');
+            }
+            $transport->setData($helper->__('customer_type'), $customerType);
+            $transport->setData($ssnLabel, $additionalData['svea_ssn']);
+        }
+    }
+
+}

--- a/src/app/code/community/Svea/WebPay/Model/Service/Abstract.php
+++ b/src/app/code/community/Svea/WebPay/Model/Service/Abstract.php
@@ -211,7 +211,23 @@ abstract class Svea_WebPay_Model_Service_Abstract extends Svea_WebPay_Model_Abst
      */
     public function authorize(Varien_Object $payment, $amount)
     {
+
         $order = $payment->getOrder();
+
+        // For Finland the ssn should be collected but no authorization should be
+        // performed.
+        if ($order->getBillingAddress()->getCountryId() == 'FI') {
+            // return;
+            $sveaInfo = @$_POST['payment']['svea_invoice'];
+            if (!is_array($sveaInfo)) {
+                throw new Mage_Exception("Error when saving order: Svea invoice information not set in _POST");
+            } else {
+                $paymentInfo = $this->getInfoInstance();
+                $paymentInfo->setAdditionalInformation($sveaInfo);
+                return;
+            }
+        }
+
         // Object created in validate()
         $sveaObject = $order->getData('svea_payment_request');
         $sveaObject = $this->_choosePayment($sveaObject);

--- a/src/app/code/community/Svea/WebPay/Model/Service/Abstract.php
+++ b/src/app/code/community/Svea/WebPay/Model/Service/Abstract.php
@@ -55,6 +55,11 @@ abstract class Svea_WebPay_Model_Service_Abstract extends Svea_WebPay_Model_Abst
         $sveaInformation = $payment->getAdditionalInformation();
 
         $order = $payment->getOrder();
+        // We don't do getAddress() requests for Finland
+        $billingCountryId = $order->getBillingAddress()->getCountryId();
+        if ($billingCountryId === 'FI') {
+            return;
+        }
         if (!empty($sveaInformation) && !empty($sveaInformation['svea_addressSelector'])) {
             // Get address has been used, and we need to override the billing
             // address that the customer has entered, and possibly also the
@@ -122,11 +127,11 @@ abstract class Svea_WebPay_Model_Service_Abstract extends Svea_WebPay_Model_Abst
                 if ($sveaInformation['svea_customerType'] == 0) {
                     // Don't overwrite the name if a company
                     $orderAddress->setFirstname($address->firstName)
-                        ->setLastname($address->lastName . ' ' . $address->coAddress);
+                                 ->setLastname($address->lastName . ' ' . $address->coAddress);
                 }
                 $orderAddress->setCity($address->locality)
-                    ->setPostcode($address->zipCode)
-                    ->setStreet($address->street);
+                             ->setPostcode($address->zipCode)
+                             ->setStreet($address->street);
             }
         } else if (in_array($order->getBillingAddress()->getCountryId(), array('SE', 'DK'))) {
             $message = Mage::helper('svea_webpay')->__('Please click the "Get Address" button to fetch your address information and proceed.');
@@ -214,17 +219,16 @@ abstract class Svea_WebPay_Model_Service_Abstract extends Svea_WebPay_Model_Abst
 
         $order = $payment->getOrder();
 
-        // For Finland the ssn should be collected but no authorization should be
-        // performed.
+        // For Finland the values in _POST should be used, not
+        // previously stored information because no getAddress() request has been
+        // made.
         if ($order->getBillingAddress()->getCountryId() == 'FI') {
-            // return;
-            $sveaInfo = @$_POST['payment']['svea_invoice'];
+            $sveaInfo = @$_POST['payment'][@$_POST['payment']['method']];
             if (!is_array($sveaInfo)) {
                 throw new Mage_Exception("Error when saving order: Svea invoice information not set in _POST");
             } else {
                 $paymentInfo = $this->getInfoInstance();
                 $paymentInfo->setAdditionalInformation($sveaInfo);
-                return;
             }
         }
 

--- a/src/app/code/community/Svea/WebPay/etc/config.xml
+++ b/src/app/code/community/Svea/WebPay/etc/config.xml
@@ -168,6 +168,15 @@
                     </add_payment_fee_total_to_block>
                 </observers>
             </core_block_abstract_to_html_before>
+            <payment_info_block_prepare_specific_information>
+                <observers>
+                    <add_svea_payment_info>
+                        <type>singleton</type>
+                        <class>svea_webpay/observer</class>
+                        <method>addSveaPaymentInfo</method>
+                    </add_svea_payment_info>
+                </observers>
+            </payment_info_block_prepare_specific_information>
         </events>
     </global>
 

--- a/src/app/design/frontend/base/default/template/svea/payment/service/ssn.phtml
+++ b/src/app/design/frontend/base/default/template/svea/payment/service/ssn.phtml
@@ -61,8 +61,9 @@ $_country = Mage::getSingleton('checkout/session')
             </label>
 
             <div class="input-box">
-                <input type="text" id="payment_form_ssn_<?php echo $_code ?>"
-                       class="svea-ssn-input input-text required-entry"
+                <input type="text"
+                       id="payment_form_ssn_<?php echo $_code ?>"
+                       class="svea-ssn-input validate-svea-invoice-ssn input-text required-entry"
                        name="payment[<?php echo $_code ?>][svea_ssn]"/>
             </div>
 


### PR DESCRIPTION
For Finland the ssn/orgnr is required _but_ a call to getAddress()
should not be done. The ssn and customertype is displayed when viewing
orders.

Fixes #106