### PR TITLE
SVEA-88: Storing billing country in svea template

### DIFF
--- a/src/app/design/frontend/base/default/template/svea/payment/service/ssn.phtml
+++ b/src/app/design/frontend/base/default/template/svea/payment/service/ssn.phtml
@@ -20,6 +20,15 @@ $_country = Mage::getSingleton('checkout/session')
 ?>
 
 <div class="svea-ssn-container <?php echo $_class ?>">
+    <?php
+    /** The hidden input below is used to find out country in checkouts that
+     * doesn't display billing:country_id, like the magento old checkout
+     * (not onepage).
+     *
+     * See _sveaGetBillingCountryCode() in svea.js.
+     */
+    ?>
+    <input type="hidden" id="svea-billing-country-id-<?php echo $_code; ?>" disabled name="svea-billing-country-id" value="<?php echo $_country; ?>">
 
     <?php if ($_useCustomerTypeSelector): ?>
         <?php

--- a/src/js/svea.js
+++ b/src/js/svea.js
@@ -178,13 +178,18 @@ function _sveaGetPaymentMethodCode() {
  * @returns Billing country code or null
  */
 function _sveaGetBillingCountryCode() {
-    var elem = $$('[name="billing[country_id]"]');
+    var billingCountryElement = $$('[name="billing[country_id]"]');
 
-    if (elem.length) {
-        return elem[0].value;
+    if (billingCountryElement.length) {
+        return billingCountryElement[0].value;
     } else {
-        // console.warn("Cannot find country_id");
-        return null;
+        billingCountryElement = $('svea-billing-country-id-' + _sveaGetPaymentMethodCode());
+        if (billingCountryElement) {
+            return billingCountryElement.value;
+        } else {
+            // console.warn('Could not find billing country id');
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
Not all checkouts has a billing:country_id input. If that input is
missing the svea input with billing country id set serverside will be
used instead.