### PR TITLE
SVEA-130: using isset instead of @

### DIFF
--- a/src/app/code/community/Svea/WebPay/Model/System/Config/Backend/Customer/Import.php
+++ b/src/app/code/community/Svea/WebPay/Model/System/Config/Backend/Customer/Import.php
@@ -27,7 +27,7 @@ class Svea_Webpay_Model_System_Config_Backend_Customer_Import extends Mage_Core_
 
     public function _afterSave()
     {
-        if (empty(@$_FILES['groups']['tmp_name']['svea_general']['fields']['import_customer_addresses']['value'])) {
+        if (!isset($_FILES['groups']['tmp_name']['svea_general']['fields']['import_customer_addresses']['value'])) {
             return $this;
         } else {
             try {


### PR DESCRIPTION
empty(@$array['some']['path']) does not work in php 5.4.